### PR TITLE
Add GitHub Pages roadmap site

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,3 +604,6 @@ Favicon
 [Hello World!] Sense — Plan — Act – StreetDrone
 
 https://www.streetdrone.com/hello-world-sense-plan-act/
+
+## GitHub Pages
+To view this roadmap as an interactive website, enable **GitHub Pages** in repository settings and select the `docs/` folder as the source.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Embedded to Autonomous Robotics Roadmap</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Embedded to Autonomous Robotics Roadmap</h1>
+    <nav>
+        <ul>
+            <li><a href="#intro">Introduction</a></li>
+            <li><a href="#embedded">Embedded Systems</a></li>
+            <li><a href="#rtos">Real-Time OS</a></li>
+            <li><a href="#control">Control Systems</a></li>
+            <li><a href="#ml">Machine Learning</a></li>
+            <li><a href="#autonomous">Autonomous Driving</a></li>
+        </ul>
+    </nav>
+    <section id="intro">
+        <h2>Introduction</h2>
+        <p>This roadmap spans from programming bare-metal hardware to high level robotics and autonomous vehicle systems.</p>
+    </section>
+    <section id="embedded">
+        <h2>Embedded Systems Fundamentals</h2>
+        <details>
+            <summary>Read more</summary>
+            <p>An embedded system is a specialized computing unit dedicated to specific functions. Bare-metal programming interacts directly with hardware for maximum efficiency.</p>
+        </details>
+    </section>
+    <section id="rtos">
+        <h2>Real-Time Operating Systems</h2>
+        <details>
+            <summary>Read more</summary>
+            <p>RTOS are lightweight operating systems designed for predictable timing and concurrency in embedded environments.</p>
+        </details>
+    </section>
+    <section id="control">
+        <h2>Control Systems in Robotics</h2>
+        <details>
+            <summary>Read more</summary>
+            <p>Control theory regulates dynamic systems by comparing current state to a desired state and minimizing error using feedback.</p>
+        </details>
+    </section>
+    <section id="ml">
+        <h2>Machine Learning and AI</h2>
+        <details>
+            <summary>Read more</summary>
+            <p>Modern robotics relies on machine learning for perception and decision making. Deep networks trained on large datasets are widely used.</p>
+        </details>
+    </section>
+    <section id="autonomous">
+        <h2>Autonomous Driving Systems</h2>
+        <details>
+            <summary>Read more</summary>
+            <p>Autonomous vehicles combine embedded systems, sensor fusion, planning and AI to safely navigate roads.</p>
+        </details>
+    </section>
+    <footer>
+        <p>Based on the roadmap from README.md. Enable GitHub Pages on the docs/ folder to publish this site.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,11 @@
+// Simple script to close other open details when one opens
+const allDetails = document.querySelectorAll('details');
+allDetails.forEach(d => {
+  d.addEventListener('toggle', () => {
+    if (d.open) {
+      allDetails.forEach(other => {
+        if (other !== d) other.removeAttribute('open');
+      });
+    }
+  });
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,22 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0 1em;
+    background-color: #f8f9fa;
+}
+nav ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    gap: 1em;
+}
+nav a {
+    text-decoration: none;
+}
+section {
+    margin-bottom: 1.5em;
+}
+summary {
+    cursor: pointer;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- create `docs/` folder for GitHub Pages
- add interactive HTML roadmap summarizing the README
- include simple styling and script for accordion sections
- mention in README how to enable Pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68433f84da0c832099132641a58be8fc